### PR TITLE
fix: update for recent CMake and Matlab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 # Directories
 build
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 2.4.0) 
-# for FindMatlab support (may require a later version to detect the latest Matlab release)
+cmake_minimum_required(VERSION 3.14.0)
+
 
 project(matlab-mexutils)
 
-option(MatlabMexutils_BuildExamples "Turn on to build example MEX files")
-option(MatlabMexutils_BuildDocs "Turn on to build Doxygen documentation")
+
+option(MatlabMexutils_BuildExamples "Turn on to build example MEX files" OFF)
+option(MatlabMexutils_BuildDocs "Turn on to build Doxygen documentation" OFF)
 
 # get the MATLAB user folder (par MATHWORKS website)
 if (WIN32)
@@ -13,20 +14,9 @@ else()
   set(MATLAB_USER_DIR "$ENV{home}/Documents/MATLAB" CACHE PATH "Matlab User Directory")
 endif()
 
-# Check if pybind11 is being used directly or via add_subdirectory
-set(MEXUTILS_MASTER_PROJECT OFF)
-if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(MEXUTILS_MASTER_PROJECT ON)
-  set(MatlabMexutils_BuildExamples CACHE BOOL OFF FORCE)
-  set(MatlabMexutils_BuildDocs CACHE BOOL OFF FORCE)
-endif()
-
 # Look for MATLAB API library paths
-find_package(Matlab REQUIRED COMPONENTS MX_LIBRARY)
-# Libmex library included by default.
-# This demo target only requires MX_LIBRARY (libmx) in addition
-# add other components as needed. See Modules/FindMatlab.cmake or it 
-# documentation for other supported components. 
+# See https://cmake.org/cmake/help/latest/module/FindMatlab.html for extra components
+find_package(Matlab REQUIRED)
 
 get_filename_component(Matlab_RELEASE ${Matlab_ROOT_DIR} NAME)
 matlab_get_version_from_release_name(${Matlab_RELEASE} Matlab_VERSION)
@@ -37,20 +27,17 @@ endif()
 # turn off new Matlab class support
 set(Matlab_HAS_CPP_API 0)
 
-# interface library for mex related files
-add_library(libmex INTERFACE)
-target_include_directories(libmex INTERFACE ${Matlab_INCLUDE_DIRS})
-target_link_libraries(libmex INTERFACE ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY})
-
 # header-only interface mexutils library
-add_library(libmexutils INTERFACE)
-target_include_directories(libmexutils INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(libmexutils INTERFACE libmex)
+add_library(mexutils INTERFACE)
+target_include_directories(mexutils INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_link_libraries(mexutils INTERFACE Matlab::mex Matlab::mx)
 
 if (MatlabMexutils_BuildExamples)
   # Set the installation directory if not already given in cache
   if (NOT MEXCPP_DEMO_INSTALL_DIR)
-    # By default, installer creates `mexcpp_demo` folder in the 
+    # By default, installer creates `mexcpp_demo` folder in the
     # default MATLAB folder in the user account folder.
 
     # Append `mexcpp_demo` to the dir

--- a/examples/@mexClass/CMakeLists.txt
+++ b/examples/@mexClass/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MEX_FILE "mexfcn") # name of MEX file
 set(MEX_FILE_NAME "mexClass_mexfcn.cpp") # source file defining mexFunction()
 
 matlab_add_mex(NAME ${MEX_FILE} SRC ${MEX_FILE_NAME})
-target_link_directories(${MEX_FILE} PRIVATE matlab-mexutils)
+target_link_libraries(${MEX_FILE} mexutils)
 
 # install
 file(RELATIVE_PATH DstRelativePath "${CMAKE_SOURCE_DIR}/examples" ${CMAKE_CURRENT_SOURCE_DIR})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # compile back-end mex function for mexClass_demo class
 matlab_add_mex(NAME mexCounter SRC mexCounter.cpp)
-target_link_directories(mexClass PRIVATE matlab-mexutils)
+target_link_libraries(mexCounter mexutils)
 
 # if the compiler is MS VisualC++, add 'mexFunction' to the exported symbols
 if(WIN32 AND MSVC)

--- a/include/mexGetString.h
+++ b/include/mexGetString.h
@@ -5,7 +5,7 @@
 #include <mex.h>
 #include <string>
 
-std::string mexGetString(const mxArray *array)
+inline std::string mexGetString(const mxArray *array)
 {
   // ideally use std::codecvt but VSC++ does not support this particular template specialization as of 2017
   // mxChar *str_utf16 = mxGetChars(array);
@@ -13,7 +13,7 @@ std::string mexGetString(const mxArray *array)
   //   throw 0;
   // std::string str = std::wstring_convert<std::codecvt_utf8_utf16<mxChar>, mxChar>{}.to_bytes(str_utf16);
 
-  // convert a scalar cell-string 
+  // convert a scalar cell-string
   if (mxIsCell(array) && mxIsScalar(array))
     return mexGetString(mxGetCell(array, 0));
 

--- a/include/mexRuntimeError.h
+++ b/include/mexRuntimeError.h
@@ -15,13 +15,13 @@ public:
   mexRuntimeError(char const *ident, char const *const message) throw() : std::runtime_error(message), id_str(ident)
   {
   }
-  mexRuntimeError(std::string &message) throw() : std::runtime_error(message.c_str())
+  mexRuntimeError(const std::string &message) throw() : std::runtime_error(message.c_str())
   {
   }
-  mexRuntimeError(std::string &ident, std::string &message) throw() : std::runtime_error(message.c_str()), id_str(ident)
+  mexRuntimeError(const std::string &ident, const std::string &message) throw() : std::runtime_error(message.c_str()), id_str(ident)
   {
   }
-  mexRuntimeError(std::string &ident, char const *const message) throw() : std::runtime_error(message), id_str(ident)
+  mexRuntimeError(const std::string &ident, char const *const message) throw() : std::runtime_error(message), id_str(ident)
   {
   }
   virtual char const *id() const throw() { return id_str.c_str(); }


### PR DESCRIPTION
- fix: update the build system for recent CMake and Matlab
- fix: fix mexRuntimeError methods
- fix: fix includes in mexObjectHandler
- fix: fix the definition of inline functions in the header